### PR TITLE
Remove ros console header and add mandatory hearders

### DIFF
--- a/include/BaselineFootstepPlanner/FootstepTypes.h
+++ b/include/BaselineFootstepPlanner/FootstepTypes.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <string>
+
 namespace BFP
 {
 /** \brief Foot. */

--- a/src/FootstepState.cpp
+++ b/src/FootstepState.cpp
@@ -1,6 +1,6 @@
 /* Author: Masaki Murooka */
 
-#include <math.h>
+#include <cmath>
 
 #include <BaselineFootstepPlanner/FootstepState.h>
 #include <BaselineFootstepPlanner/console.h>

--- a/src/FootstepState.cpp
+++ b/src/FootstepState.cpp
@@ -1,6 +1,6 @@
 /* Author: Masaki Murooka */
 
-#include <ros/console.h>
+#include <math.h>
 
 #include <BaselineFootstepPlanner/FootstepState.h>
 #include <BaselineFootstepPlanner/console.h>


### PR DESCRIPTION
As ROS2 is not using the same headers as ROS1, ros/console must be drop. Furthermore, this one is already included in include/BaselineFootstepPlanner/console.h. 

Concerning the other headers, they are needed to compile. 